### PR TITLE
fixes active sale event listing (only show events for selected sale), an...

### DIFF
--- a/app/controllers/spree/admin/active_sale_events_controller.rb
+++ b/app/controllers/spree/admin/active_sale_events_controller.rb
@@ -18,7 +18,7 @@ module Spree
 
         def collection
           return @collection if @collection.present?
-          @search = Spree::ActiveSaleEvent.ransack(params[:q])
+          @search = Spree::ActiveSaleEvent.where(:active_sale_id => params[:active_sale_id]).ransack(params[:q])
           @collection = @search.result.page(params[:page]).per(Spree::ActiveSaleConfig[:admin_active_sale_events_per_page])
         end
 

--- a/app/helpers/spree/active_sale_events_helper.rb
+++ b/app/helpers/spree/active_sale_events_helper.rb
@@ -3,7 +3,7 @@ module Spree
     
     def sale_event_timer(event = nil)
       return I18n.t('spree.active_sale.event.can_not_be_nil') if (event == nil) || (event.class.name != "Spree::ActiveSaleEvent")
-      content_tag(:span, I18n.t('spree.active_sale.event.ending_message'), :class => 'sale_event_message') + " " + content_tag(:span, event.end_date.getlocal.strftime('%Y-%m-%dT%H:%M:%S'), "data-timer" => event.end_date.getlocal.strftime('%Y-%m-%dT%H:%M:%S'), :class => 'sale_event_message')
+      content_tag(:span, I18n.t('spree.active_sale.event.ending_message'), :class => 'sale_event_message') + " " + content_tag(:span, event.end_date.utc.strftime('%Y-%m-%dT%H:%M:%S'), "data-timer" => event.end_date.utc.strftime('%Y-%m-%dT%H:%M:%S'), :class => 'sale_event_message')
     end
 
     def method_missing(method_name, *args, &block)


### PR DESCRIPTION
...d use UTC, not local time, to initialize the countdown

If you create an event in the admin then go back to the store, you'll see that the timer is off (by 5 hours in my case, as I'm in UTC-5).

Also, urls like:

http://localhost:3000/admin/active_sales/2/active_sale_events

were returning _all_ events, not just the ones that belonged to #2.
